### PR TITLE
Fix/backend api responses

### DIFF
--- a/friendships-service/src/main/kotlin/piperkt/services/friendships/interfaces/web/FriendshipHttpController.kt
+++ b/friendships-service/src/main/kotlin/piperkt/services/friendships/interfaces/web/FriendshipHttpController.kt
@@ -87,7 +87,7 @@ class FriendshipHttpController(private val friendshipService: FriendshipService)
                     FriendshipQuery.GetFriendships.Request(requestFrom = principal.name)
                 )
                 .getOrThrow()
-        return FriendshipApi.GetFriendships.Response(friendships = response.friendships)
+        return FriendshipApi.GetFriendships.Response(friends = response.friendships)
     }
 
     @Get("users/{friendUsername}/messages")

--- a/friendships-service/src/main/kotlin/piperkt/services/friendships/interfaces/web/api/dto/MessageDTO.kt
+++ b/friendships-service/src/main/kotlin/piperkt/services/friendships/interfaces/web/api/dto/MessageDTO.kt
@@ -23,7 +23,7 @@ data class MessageDTO(
     companion object {
         fun fromDomain(message: Message): MessageDTO {
             return MessageDTO(
-                id = message.id.toString(),
+                id = message.id.value,
                 sender = message.sender,
                 content = message.content,
                 timestamp = message.timestamp.toString()

--- a/friendships-service/src/main/kotlin/piperkt/services/friendships/interfaces/web/api/interactions/FriendshipApi.kt
+++ b/friendships-service/src/main/kotlin/piperkt/services/friendships/interfaces/web/api/interactions/FriendshipApi.kt
@@ -47,6 +47,6 @@ sealed interface FriendshipApi {
     }
 
     sealed interface GetFriendships : FriendshipApi {
-        @Serdeable data class Response(val friendships: List<String>) : GetFriendships
+        @Serdeable data class Response(val friends: List<String>) : GetFriendships
     }
 }

--- a/servers-service/src/main/kotlin/piperkt/services/servers/interfaces/web/api/dto/ChannelDTO.kt
+++ b/servers-service/src/main/kotlin/piperkt/services/servers/interfaces/web/api/dto/ChannelDTO.kt
@@ -19,7 +19,7 @@ data class ChannelDTO(
     companion object {
         fun fromDomain(channel: Channel): ChannelDTO {
             return ChannelDTO(
-                id = channel.id.toString(),
+                id = channel.id.value,
                 name = channel.name,
                 type = channel.type.toString(),
                 description = channel.description,

--- a/servers-service/src/main/kotlin/piperkt/services/servers/interfaces/web/api/dto/MessageDTO.kt
+++ b/servers-service/src/main/kotlin/piperkt/services/servers/interfaces/web/api/dto/MessageDTO.kt
@@ -23,7 +23,7 @@ data class MessageDTO(
     companion object {
         fun fromDomain(message: Message): MessageDTO {
             return MessageDTO(
-                id = message.id.toString(),
+                id = message.id.value,
                 sender = message.sender,
                 content = message.content,
                 timestamp = message.timestamp.toString()

--- a/servers-service/src/main/kotlin/piperkt/services/servers/interfaces/web/api/dto/ServerDTO.kt
+++ b/servers-service/src/main/kotlin/piperkt/services/servers/interfaces/web/api/dto/ServerDTO.kt
@@ -25,7 +25,7 @@ data class ServerDTO(
     companion object {
         fun fromDomain(server: Server): ServerDTO {
             return ServerDTO(
-                id = server.id.toString(),
+                id = server.id.value,
                 name = server.name,
                 description = server.description,
                 owner = server.owner,


### PR DESCRIPTION
Fix params names in a endpoints to match frontend controller specifications and return ids value instead of object id in http responses.